### PR TITLE
add relationships on same table examples

### DIFF
--- a/app/Http/Livewire/UsersTable.php
+++ b/app/Http/Livewire/UsersTable.php
@@ -113,6 +113,14 @@ class UsersTable extends DataTableComponent
                 ->sortable()
                 ->searchable()
                 ->collapseOnTablet(),
+            Column::make('Parent', 'parent.name')
+                ->sortable()
+                ->searchable()
+                ->collapseOnTablet(),
+            Column::make('Parent of parent', 'parent.parent.name')
+                ->sortable()
+                ->searchable()
+                ->collapseOnTablet(),
             BooleanColumn::make('Active')
                 ->sortable()
                 ->collapseOnMobile()


### PR DESCRIPTION
As requested in https://github.com/rappasoft/laravel-livewire-tables/pull/1190, this is an attempt to add examples for relationships on the same table.

These examples are interesting because they show the behavior for:
- a relationship that is on the same table that the original queried model
- a relationship of the first relation on the same table

So we have a base table and 2 relationships from the same origin.

This PR is a draft because it will generate an SQL until the PR in the package repository is merged.